### PR TITLE
#5/ id를 통한 유저조회 + 프로필 수정 -> 비밀번호 변경 API + Method 분리

### DIFF
--- a/src/main/java/december/spring/studywithme/controller/UserController.java
+++ b/src/main/java/december/spring/studywithme/controller/UserController.java
@@ -3,23 +3,14 @@ package december.spring.studywithme.controller;
 
 import december.spring.studywithme.dto.*;
 import december.spring.studywithme.jwt.JwtUtil;
-import jakarta.servlet.http.HttpServletRequest;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
-
 import december.spring.studywithme.security.UserDetailsImpl;
 import december.spring.studywithme.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -109,8 +100,6 @@ public class UserController {
                 .message("프로필 수정이 완료되었습니다.")
                 .data(userResponseDTO)
                 .build();
-
         return new ResponseEntity<>(responseMessage, HttpStatus.OK);
-
     }
 }

--- a/src/main/java/december/spring/studywithme/controller/UserController.java
+++ b/src/main/java/december/spring/studywithme/controller/UserController.java
@@ -2,7 +2,6 @@ package december.spring.studywithme.controller;
 
 
 import december.spring.studywithme.dto.*;
-import december.spring.studywithme.exception.UserException;
 import december.spring.studywithme.jwt.JwtUtil;
 import december.spring.studywithme.security.UserDetailsImpl;
 import december.spring.studywithme.service.UserService;
@@ -81,6 +80,7 @@ public class UserController {
                 .build());
     }
 
+
     @GetMapping("/{id}")
     public ResponseEntity<ResponseMessage<UserResponseDTO>> getProfileById(@PathVariable Long id) {
         UserResponseDTO userResponseDTO = userService.inquiryUserById(id);
@@ -91,8 +91,8 @@ public class UserController {
     }
 
     @PutMapping("/mypage")
-    public ResponseEntity<ResponseMessage<UserResponseDTO>> updateUser(@Valid @RequestBody UserProfileUpateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        UserResponseDTO userResponseDTO = userService.updateProfile(requestDTO, userDetails.getUser());
+    public ResponseEntity<ResponseMessage<UserResponseDTO>> updateUser(@Valid @RequestBody UserProfileUpdateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserResponseDTO userResponseDTO = userService.editProfile(requestDTO, userDetails.getUser());
         ResponseMessage<UserResponseDTO> responseMessage = ResponseMessage.<UserResponseDTO>builder()
                 .statusCode(HttpStatus.OK.value())
                 .message("프로필 수정이 완료되었습니다.")
@@ -100,15 +100,15 @@ public class UserController {
                 .build();
         return new ResponseEntity<>(responseMessage, HttpStatus.OK);
     }
+
+    @PutMapping("/password")
+    public ResponseEntity<ResponseMessage<UserResponseDTO>> updatePassword(@Valid @RequestBody EditPasswordRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserResponseDTO userResponseDTO = userService.editPassword(requestDTO, userDetails);
+        ResponseMessage<UserResponseDTO> responseMessage = ResponseMessage.<UserResponseDTO>builder()
+                .statusCode(HttpStatus.OK.value())
+                .message("비밀번호가 변경되었습니다.")
+                .data(userResponseDTO)
+                .build();
+        return new ResponseEntity<>(responseMessage, HttpStatus.OK);
+    }
 }
-//
-//    @PutMapping("/password")
-//
-//    String editPassword = requestDTO.getNewPassword() != null ? passwordEncoder.encode(requestDTO.getNewPassword()) : user.getPassword();
-//
-//            if (!passwordEncoder.matches(requestDTO.getCurrentPassword(), user.getPassword())) {
-//        throw new UserException("비밀번호가 일치하지 않습니다.");
-//    }
-//        if (passwordEncoder.matches(requestDTO.getNewPassword(), user.getPassword())) {
-//        throw new UserException("새로운 비밀번호와 기존 비밀번호가 동일합니다.");
-//}

--- a/src/main/java/december/spring/studywithme/controller/UserController.java
+++ b/src/main/java/december/spring/studywithme/controller/UserController.java
@@ -5,6 +5,7 @@ import december.spring.studywithme.dto.*;
 import december.spring.studywithme.jwt.JwtUtil;
 import december.spring.studywithme.security.UserDetailsImpl;
 import december.spring.studywithme.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/december/spring/studywithme/controller/UserController.java
+++ b/src/main/java/december/spring/studywithme/controller/UserController.java
@@ -2,6 +2,7 @@ package december.spring.studywithme.controller;
 
 
 import december.spring.studywithme.dto.*;
+import december.spring.studywithme.exception.UserException;
 import december.spring.studywithme.jwt.JwtUtil;
 import december.spring.studywithme.security.UserDetailsImpl;
 import december.spring.studywithme.service.UserService;
@@ -89,12 +90,9 @@ public class UserController {
                 .build());
     }
 
-    @PutMapping()
-    public ResponseEntity<ResponseMessage<UserResponseDTO>> updateUser(@RequestBody UserProfileUpateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        // 현재 사용자의 인증 정보 가져오기
-            // 사용자 정보 수정
+    @PutMapping("/mypage")
+    public ResponseEntity<ResponseMessage<UserResponseDTO>> updateUser(@Valid @RequestBody UserProfileUpateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         UserResponseDTO userResponseDTO = userService.updateProfile(requestDTO, userDetails.getUser());
-
         ResponseMessage<UserResponseDTO> responseMessage = ResponseMessage.<UserResponseDTO>builder()
                 .statusCode(HttpStatus.OK.value())
                 .message("프로필 수정이 완료되었습니다.")
@@ -103,3 +101,14 @@ public class UserController {
         return new ResponseEntity<>(responseMessage, HttpStatus.OK);
     }
 }
+//
+//    @PutMapping("/password")
+//
+//    String editPassword = requestDTO.getNewPassword() != null ? passwordEncoder.encode(requestDTO.getNewPassword()) : user.getPassword();
+//
+//            if (!passwordEncoder.matches(requestDTO.getCurrentPassword(), user.getPassword())) {
+//        throw new UserException("비밀번호가 일치하지 않습니다.");
+//    }
+//        if (passwordEncoder.matches(requestDTO.getNewPassword(), user.getPassword())) {
+//        throw new UserException("새로운 비밀번호와 기존 비밀번호가 동일합니다.");
+//}

--- a/src/main/java/december/spring/studywithme/controller/UserController.java
+++ b/src/main/java/december/spring/studywithme/controller/UserController.java
@@ -88,6 +88,7 @@ public class UserController {
                 .data(userInfoResponseDTO)
                 .build());
     }
+
     @GetMapping("/{id}")
     public ResponseEntity<ResponseMessage<UserResponseDTO>> getProfileById(@PathVariable Long id) {
         UserResponseDTO userResponseDTO = userService.inquiryUserById(id);

--- a/src/main/java/december/spring/studywithme/controller/UserController.java
+++ b/src/main/java/december/spring/studywithme/controller/UserController.java
@@ -88,6 +88,14 @@ public class UserController {
                 .data(userInfoResponseDTO)
                 .build());
     }
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseMessage<UserResponseDTO>> getProfileById(@PathVariable Long id) {
+        UserResponseDTO userResponseDTO = userService.inquiryUserById(id);
+        return ResponseEntity.ok(ResponseMessage.<UserResponseDTO>builder()
+                .statusCode(HttpStatus.OK.value())
+                .data(userResponseDTO)
+                .build());
+    }
 
     @PutMapping()
     public ResponseEntity<ResponseMessage<UserResponseDTO>> updateUser(@RequestBody UserProfileUpateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/december/spring/studywithme/dto/EditPasswordRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/EditPasswordRequestDTO.java
@@ -3,9 +3,10 @@ package december.spring.studywithme.dto;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
-public class editPasswordRequestDTO {
+@Getter
+public class EditPasswordRequestDTO {
 
     @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")

--- a/src/main/java/december/spring/studywithme/dto/PasswordRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/PasswordRequestDTO.java
@@ -1,12 +1,25 @@
 package december.spring.studywithme.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
 
-@Getter
-@Setter
+@Data
 public class PasswordRequestDTO {
-	@NotBlank(message = "비밀번호를 입력해주세요.")
-	private String password;
+
+    private String userId;
+
+    private String name;
+
+    private String introduce;
+
+    @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
+    private String currentPassword;
+
+    @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
+    private String newPassword;
+
+
 }

--- a/src/main/java/december/spring/studywithme/dto/PasswordRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/PasswordRequestDTO.java
@@ -1,11 +1,16 @@
 package december.spring.studywithme.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class PasswordRequestDTO {
+
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
 
     private String userId;
 

--- a/src/main/java/december/spring/studywithme/dto/PasswordRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/PasswordRequestDTO.java
@@ -4,27 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class PasswordRequestDTO {
-
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
-
-    private String userId;
-
-    private String name;
-
-    private String introduce;
-
-    @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
-    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
-    private String currentPassword;
-
-    @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
-    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
-    private String newPassword;
-
-
 }

--- a/src/main/java/december/spring/studywithme/dto/UserProfileUpdateRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/UserProfileUpdateRequestDTO.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Data
-public class UserProfileUpateRequestDTO {
+public class UserProfileUpdateRequestDTO {
 
     private String userId;
 
@@ -19,7 +19,7 @@ public class UserProfileUpateRequestDTO {
 
     @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
-    private String currentPasdsword;
+    private String currentPassword;
 
 
 

--- a/src/main/java/december/spring/studywithme/dto/UserRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/UserRequestDTO.java
@@ -1,9 +1,6 @@
 package december.spring.studywithme.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,6 +24,6 @@ public class UserRequestDTO {
 	@NotBlank(message = "이메일을 입력해 주세요.")
 	@Email(message = "이메일 형식을 입력해 주세요.")
 	private String email;
-	
+
 	private String introduce;
 }

--- a/src/main/java/december/spring/studywithme/dto/UserResponseDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/UserResponseDTO.java
@@ -3,6 +3,7 @@ package december.spring.studywithme.dto;
 import java.time.LocalDateTime;
 
 import december.spring.studywithme.entity.User;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,6 +14,7 @@ public class UserResponseDTO {
 	private String userId;
 	private String name;
 	private String email;
+	private String introduce;
 	private LocalDateTime createAt;
 	private LocalDateTime modifyAt;
 	
@@ -21,6 +23,7 @@ public class UserResponseDTO {
 		this.userId = user.getUserId();
 		this.name = user.getName();
 		this.email = user.getEmail();
+		this.introduce = user.getIntroduce();
 		this.createAt = user.getCreateAt();
 		this.modifyAt = user.getModifyAt();
 	}

--- a/src/main/java/december/spring/studywithme/dto/editPasswordRequestDTO.java
+++ b/src/main/java/december/spring/studywithme/dto/editPasswordRequestDTO.java
@@ -1,26 +1,19 @@
 package december.spring.studywithme.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Data
-public class UserProfileUpateRequestDTO {
-
-    private String userId;
-
-    private String name;
-
-    private String introduce;
+public class editPasswordRequestDTO {
 
     @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
-    private String currentPasdsword;
+    private String currentPassword;
 
+    @Size(min = 10, message = "비밀번호는 최소 10글자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*]).+$", message = "영어 대소문자와 특수문자를 최소 1글자씩 포함해야 합니다.")
+    private String newPassword;
 
 
 }

--- a/src/main/java/december/spring/studywithme/entity/Post.java
+++ b/src/main/java/december/spring/studywithme/entity/Post.java
@@ -47,3 +47,4 @@ public class Post extends Timestamped{
 		this.contents = requestDto.getContents();
 	}
 }
+

--- a/src/main/java/december/spring/studywithme/entity/User.java
+++ b/src/main/java/december/spring/studywithme/entity/User.java
@@ -67,10 +67,12 @@ public class User extends Timestamped {
         this.userType = userType;
         this.statusChangedAt = statusChangedAt;
     }
+
     //회원 상태 변경
     public void withdrawUser() {
         this.userType = UserType.DEACTIVATED;
     }
+
     @Transactional
     //로그인시 리프레시 토큰 초기화
     public void refreshTokenReset(String refreshToken) {
@@ -80,5 +82,9 @@ public class User extends Timestamped {
     public void editProfile(String name, String introduce) {
         this.name = name;
         this.introduce = introduce;
+    }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
     }
 }

--- a/src/main/java/december/spring/studywithme/entity/User.java
+++ b/src/main/java/december/spring/studywithme/entity/User.java
@@ -77,9 +77,8 @@ public class User extends Timestamped {
         this.refreshToken = refreshToken;
     }
 
-    public void editProfile(String name, String password, String introduce) {
+    public void editProfile(String name, String introduce) {
         this.name = name;
         this.introduce = introduce;
-        this.password = password;
     }
 }

--- a/src/main/java/december/spring/studywithme/service/UserService.java
+++ b/src/main/java/december/spring/studywithme/service/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
         checkUserType(user.getUserType());
 
         //비밀번호 일치 확인
-        if (!passwordEncoder.matches(requestDTO.getPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(requestDTO.getCurrentPassword(), user.getPassword())) {
             throw new UserException("비밀번호가 일치하지 않습니다.");
         }
 
@@ -122,15 +122,14 @@ public class UserService {
     @Transactional
     public UserResponseDTO updateProfile(UserProfileUpateRequestDTO requestDTO, User user) {
 
-        if (!passwordEncoder.matches(requestDTO.getCurrentPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(requestDTO.getCurrentPasdsword(), user.getPassword())) {
             throw new UserException("비밀번호가 일치하지 않습니다.");
         }
-        if (passwordEncoder.matches(requestDTO.getNewPassword(), user.getPassword())) {
-            throw new UserException("새로운 비밀번호와 기존 비밀번호가 동일합니다.");
-        }
 
-        user.editProfile(requestDTO.getName(), passwordEncoder.encode(requestDTO.getNewPassword()), requestDTO.getIntroduce());
+        String editName = requestDTO.getName() != null ? requestDTO.getName() : user.getName();
+        String editIntroduce = requestDTO.getIntroduce() != null ? requestDTO.getIntroduce() : user.getIntroduce();
 
+        user.editProfile(editName,editIntroduce);
         userRepository.save(user);
         return new UserResponseDTO(user);
     }

--- a/src/main/java/december/spring/studywithme/service/UserService.java
+++ b/src/main/java/december/spring/studywithme/service/UserService.java
@@ -65,7 +65,7 @@ public class UserService {
         checkUserType(user.getUserType());
 
         //비밀번호 일치 확인
-        if (!passwordEncoder.matches(requestDTO.getCurrentPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(requestDTO.getPassword(), user.getPassword())) {
             throw new UserException("비밀번호가 일치하지 않습니다.");
         }
 

--- a/src/main/java/december/spring/studywithme/service/UserService.java
+++ b/src/main/java/december/spring/studywithme/service/UserService.java
@@ -177,6 +177,7 @@ public class UserService {
     /**
      * 인증 회원으로 전환
      */
+
     @Transactional
     public void updateUserActive(User user) {
         user.ActiveUser();

--- a/src/main/java/december/spring/studywithme/service/UserService.java
+++ b/src/main/java/december/spring/studywithme/service/UserService.java
@@ -112,6 +112,7 @@ public class UserService {
         User user = userRepository.findByUserId(userId).orElseThrow(() -> new UserException("해당 유저를 찾을 수 없습니다."));
         return new UserProfileResponseDTO(user);
     }
+
     public UserResponseDTO inquiryUserById(Long Id) { // 유저 아이디를 통한 조회
         User user = userRepository.findById(Id)
                 .orElseThrow(() -> new UserException("해당 유저를 찾을 수 없습니다."));

--- a/src/main/java/december/spring/studywithme/service/UserService.java
+++ b/src/main/java/december/spring/studywithme/service/UserService.java
@@ -112,6 +112,11 @@ public class UserService {
         User user = userRepository.findByUserId(userId).orElseThrow(() -> new UserException("해당 유저를 찾을 수 없습니다."));
         return new UserProfileResponseDTO(user);
     }
+    public UserResponseDTO inquiryUserById(Long Id) { // 유저 아이디를 통한 조회
+        User user = userRepository.findById(Id)
+                .orElseThrow(() -> new UserException("해당 유저를 찾을 수 없습니다."));
+        return new UserResponseDTO(user);
+    }
 
     @Transactional
     public UserResponseDTO updateProfile(UserProfileUpateRequestDTO requestDTO, User user) {


### PR DESCRIPTION
## 📌 연관된 이슈
<!-- 수정하려는 현재 동작을 설명하거나 관련 문제에 대한 링크를 제공해주세요 -->
> Issue Number : #이슈번호

## PR 종류
해당 PR은 어떤 부분에 대한 변화인가요?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] 버그 수정 `FIX`(Hotfix)
- [x] 코드 수정 `MODIFY`
- [x] 기능 추가 `FEAT`
- [x] 파일 이름 변경 `RENAME`
- [ ] 테스트 코드 추가 `TEST`
- [ ] 코드 스타일 변화 (formatting, local variables) `STYLE`
- [x] 리팩토링 (no functional changes, no api changes) `REFACTOR`
- [ ] 빌드 관련 내용 추가 및 변화 `BUILD`
- [ ] 문서 내용 추가 및 변화`DOCS`
- [ ] 기타 변경 사항 추 `CHORE`
- [ ] Other... (적어주세요 : )

## 💻 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해 주세요 (이미지 첨부 가능)

- pk값인 Long id를 통해 유저를 조회하는 기능을 구현했습니다.
- 프로필 수정시 변경된 필드는 변경된 값으로 업데이트가 되고 수정을 하지 않은 데이터는 기존 데이터를 유지하게 구현했습니다.
- 프로필 수정시 비밀번호의 포지션이 애매했습니다. 가령 유저가 현재 비밀번호를 입력하지 않으면 프로필이 수정이 되지 않게 구현을 했기에
비밀번호가 null값일 수 없습니다 따라서 매번 비밀번호를 변경하는 이슈가 발생했었고 이에따라 비밀번호 변경 API를 따로 만들어 비밀번호 로직을 따로 분리하였습니다.

## 해당 PR이 다른 영역에 영향을 미치나요?
- [ ] Yes
- [x] No

<!-- "Yes"를 선택한 경우, 어떤 영향을 끼치는지, 발생 위치 Path를 설명해주세요. -->

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요